### PR TITLE
Add ghosts properties to inspection

### DIFF
--- a/example_data/example_spec.json
+++ b/example_data/example_spec.json
@@ -22,7 +22,8 @@
         "policy:path": "section2/{beta}/{gamma:a}",
         "gamma": "#range(3.0, 7.0, 0.5)",
         "zeta": "#repeat(@Counter, 4)",
-        "eta": "$Multiplier * !gamma"
+        "eta": "$Multiplier * !gamma",
+        "_psi": 42
       }
     }
   }

--- a/spawn/specification/converters.py
+++ b/spawn/specification/converters.py
@@ -78,4 +78,6 @@ class DictSpecificationConverter(SpecificationConverter):
             node_dict['children'] = children
         else:
             node_dict['path'] = node.path
+            if len(node.ghosts) > 0:
+                node_dict['ghosts'] = node.ghosts
         return [node_dict]

--- a/spawn/specification/converters.py
+++ b/spawn/specification/converters.py
@@ -78,6 +78,6 @@ class DictSpecificationConverter(SpecificationConverter):
             node_dict['children'] = children
         else:
             node_dict['path'] = node.path
-            if len(node.ghosts) > 0:
+            if node.ghosts:
                 node_dict['ghosts'] = node.ghosts
         return [node_dict]

--- a/spawn/util/prettyspec.py
+++ b/spawn/util/prettyspec.py
@@ -40,6 +40,8 @@ def _prettyspec_impl(spec, indent, outstream):
         else:
             name = spec['name']
         outstream.write('{}{}: {}'.format(INDENT * indent, name, spec['value']))
+    if spec.get('ghosts'):
+        outstream.write(' | {}'.format(', '.join('_{}: {}'.format(k, v) for k, v in spec['ghosts'].items())))
     if spec.get('path'):
         outstream.write(' | path: {}'.format(spec['path']))
     outstream.write('\n')

--- a/spawn/util/prettyspec.py
+++ b/spawn/util/prettyspec.py
@@ -23,6 +23,7 @@ from spawn.util.validation import validate_type
 INDENT = '  '
 
 def _prettyspec_impl(spec, indent, outstream):
+    # pylint: disable=too-many-branches
     if spec.get('base_file'):
         outstream.write('base_file: {}\n'.format(spec['base_file']))
     if 'metadata' in spec:

--- a/tests/specification/converters_tests.py
+++ b/tests/specification/converters_tests.py
@@ -141,6 +141,7 @@ SPEC_4 = {
     'notes': 'Some notes',
     'spec': {
         'policy:path': 'X{alpha}/Y{beta}',
+        '_casper': 1.0,
         'combine:zip': {
             'alpha': [3.0, 12.0],
             'beta': [0.0, 180.0]
@@ -161,17 +162,19 @@ EXPECTED_4 = {
             {
                 'path': 'X3.0/Y0.0',
                 'name': 'beta',
-                'value': 0.0
+                'value': 0.0,
+                'ghosts': {'casper': 1.0}
             }
         ]
-    },{
+    }, {
         'name': 'alpha',
         'value': 12.0,
         'children': [
             {
                 'path': 'X12.0/Y180.0',
                 'name': 'beta',
-                'value': 180.0
+                'value': 180.0,
+                'ghosts': {'casper': 1.0}
             }
         ]
     }]


### PR DESCRIPTION
Ghost properties were not included in inspection of the specification at all. It's debatable the best way to do this in terms of whether to consider them "concrete" properties once the spec has been parsed. I have chosen not to and add ghost properties at the leaf only (given that they are passed all the way through the tree, including them at every node would be repetition). So:
```JSON
"children": [
  {
    "name": "alpha",
    "value": "tadpole",
    "ghosts": {"casper": 1.0}
  }
]
```