### PR TITLE
Fixing location of inspection file - outdir instead of outfile

### DIFF
--- a/spawn/interface/local.py
+++ b/spawn/interface/local.py
@@ -81,7 +81,7 @@ class LocalInterface(SpawnInterface):
             ))
         spawner = self._plugin_loader.create_spawner(plugin_type)
         scheduler = LuigiScheduler(self._config)
-        inspection_file = path.join(self._config.get(self._config.default_category, 'outfile'), 'spawn.json')
+        inspection_file = path.join(self._config.get(self._config.default_category, 'outdir'), 'spawn.json')
         LOGGER.info('Writing inspection to %s', inspection_file)
         with open(inspection_file, 'w') as fp:
             json.dump(self._spec_to_spec_dict(spec), fp, indent=2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,8 +77,8 @@ class BarSpawner(TaskSpawner):
     def branch(self):
         return BarSpawner(self._foo_spawner.branch(), self._outdir)
 
-def create_spawner(outfile):
-    return BarSpawner(FooSpawner(outfile), outfile)
+def create_spawner(outdir):
+    return BarSpawner(FooSpawner(outdir), outdir)
 
 @pytest.fixture
 def spawner(tmpdir):

--- a/tests/interface/interface_tests.py
+++ b/tests/interface/interface_tests.py
@@ -19,7 +19,7 @@ def test_tasks_are_run_via_interface(tmpdir):
     config = DefaultConfiguration()
     config.set_default('plugins', 'test:tests.conftest')
     config.set_default('type', 'test')
-    config.set_default('outfile', tmpdir)
+    config.set_default('outdir', tmpdir)
     config.set_default('workers', 1)
     config.set_default('local', True)
     spec_dict = {'spec': {'alpha': list(np.arange(4.0, 10.0, 2.0))}}


### PR DESCRIPTION
This was causing an error on `run`